### PR TITLE
Raise upper bound of directory library

### DIFF
--- a/cabal-bounds.cabal
+++ b/cabal-bounds.cabal
@@ -81,7 +81,7 @@ library
         cabal-lenses >=0.4.6 && <0.5,
         Cabal >=1.18.0 && <1.25,
         filepath >=1.3 && <1.5,
-        directory ==1.2.*
+        directory >=1.2 && <1.4
     cpp-options: -DCABAL
     hs-source-dirs: lib
     other-modules:


### PR DESCRIPTION
Tested on NixOS 17.03

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dan-t/cabal-bounds/10)
<!-- Reviewable:end -->
