### PR TITLE
Port to Cabal 3, allow lens 4.19, lens-aeson 1.1

### DIFF
--- a/cabal-bounds.cabal
+++ b/cabal-bounds.cabal
@@ -98,16 +98,16 @@ library
     build-depends:
         base >=4.6.0.0 && <5,
         cmdargs >=0.10.5 && <0.11,
-        lens >=4.0.1 && <4.18,
+        lens >=4.0.1 && <4.20,
         strict >=0.3.2 && <0.4,
         unordered-containers >=0.2.3.3 && <0.3,
         transformers >=0.3.0.0 && <0.6,
         cabal-lenses >=0.8.0 && <1.0,
-        Cabal >=2.2.0.0 && <2.5,
+        Cabal >=3.0.0.0 && <4.0,
         filepath >=1.3 && <1.5,
         directory >=1.2 && <1.4,
         aeson >=1.2.3.0 && <1.5,
-        lens-aeson >=1.0.2 && <1.1,
+        lens-aeson >=1.0.2 && <1.2,
         bytestring >=0.10.8.2 && <1.0,
         text >=1.1.0.1 && <1.3
 

--- a/lib/CabalBounds/Dependencies.hs
+++ b/lib/CabalBounds/Dependencies.hs
@@ -40,10 +40,10 @@ filterDependency AllDependencies =
    filtered (const True)
 
 filterDependency (OnlyDependencies deps) =
-   filtered (\(Dependency pkg _) -> (unPackageName pkg) `elem` deps)
+   filtered (\(Dependency pkg _ _) -> (unPackageName pkg) `elem` deps)
 
 filterDependency (IgnoreDependencies deps) =
-   filtered (\(Dependency pkg _) -> (unPackageName pkg) `notElem` deps)
+   filtered (\(Dependency pkg _ _) -> (unPackageName pkg) `notElem` deps)
 
 
 -- | A traversal for all 'Dependency' of all 'Section'.

--- a/lib/CabalBounds/Main.hs
+++ b/lib/CabalBounds/Main.hs
@@ -6,7 +6,7 @@ module CabalBounds.Main
 
 import Distribution.PackageDescription (GenericPackageDescription)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
-import Distribution.Parsec.Common (PWarning)
+import Distribution.Parsec.Warning (PWarning)
 import qualified Distribution.PackageDescription.PrettyPrint as PP
 import Distribution.Simple.Configure (tryGetConfigStateFile)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)

--- a/tests/goldenFiles/DropBothIgnoreA.cabal
+++ b/tests/goldenFiles/DropBothIgnoreA.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D -any
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOfAll.cabal
+++ b/tests/goldenFiles/DropBothOfAll.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A -any,
@@ -23,8 +23,8 @@ library
         D -any
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,

--- a/tests/goldenFiles/DropBothOfAllExes.cabal
+++ b/tests/goldenFiles/DropBothOfAllExes.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOfExe.cabal
+++ b/tests/goldenFiles/DropBothOfExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOfLib.cabal
+++ b/tests/goldenFiles/DropBothOfLib.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A -any,
@@ -23,8 +23,8 @@ library
         D -any
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOfOtherExe.cabal
+++ b/tests/goldenFiles/DropBothOfOtherExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOfTest.cabal
+++ b/tests/goldenFiles/DropBothOfTest.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A -any,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropBothOnlyBase.cabal
+++ b/tests/goldenFiles/DropBothOnlyBase.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base -any,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base -any,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base -any,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base -any,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base -any,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperIgnoreA.cabal
+++ b/tests/goldenFiles/DropUpperIgnoreA.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOfAll.cabal
+++ b/tests/goldenFiles/DropUpperOfAll.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,

--- a/tests/goldenFiles/DropUpperOfAllExes.cabal
+++ b/tests/goldenFiles/DropUpperOfAllExes.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOfExe.cabal
+++ b/tests/goldenFiles/DropUpperOfExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D -any
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOfLib.cabal
+++ b/tests/goldenFiles/DropUpperOfLib.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOfOtherExe.cabal
+++ b/tests/goldenFiles/DropUpperOfOtherExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOfTest.cabal
+++ b/tests/goldenFiles/DropUpperOfTest.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/DropUpperOnlyBase.cabal
+++ b/tests/goldenFiles/DropUpperOnlyBase.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/Format.cabal
+++ b/tests/goldenFiles/Format.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothIgnoreA.cabal
+++ b/tests/goldenFiles/UpdateBothIgnoreA.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2 && <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2 && <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothOfAll.cabal
+++ b/tests/goldenFiles/UpdateBothOfAll.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2 && <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2 && <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,

--- a/tests/goldenFiles/UpdateBothOfAllExes.cabal
+++ b/tests/goldenFiles/UpdateBothOfAllExes.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2 && <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothOfExe.cabal
+++ b/tests/goldenFiles/UpdateBothOfExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothOfLibrary.cabal
+++ b/tests/goldenFiles/UpdateBothOfLibrary.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothOfOtherExe.cabal
+++ b/tests/goldenFiles/UpdateBothOfOtherExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2 && <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateBothOfTest.cabal
+++ b/tests/goldenFiles/UpdateBothOfTest.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2 && <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateByHaskellPlatform.cabal
+++ b/tests/goldenFiles/UpdateByHaskellPlatform.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         directory >=1.0 && <1.3
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -40,8 +41,8 @@ executable cabal-bounds
         C >=0.1 && <0.4
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -49,7 +50,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -57,8 +59,8 @@ executable other-exe
         C >=0.1 && <0.4
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -66,7 +68,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -74,8 +77,8 @@ test-suite some-test
         C >=0.1 && <0.4
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -83,7 +86,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateLowerOfAll.cabal
+++ b/tests/goldenFiles/UpdateLowerOfAll.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,

--- a/tests/goldenFiles/UpdateLowerOfAllExes.cabal
+++ b/tests/goldenFiles/UpdateLowerOfAllExes.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateLowerOfExe.cabal
+++ b/tests/goldenFiles/UpdateLowerOfExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateLowerOfLibrary.cabal
+++ b/tests/goldenFiles/UpdateLowerOfLibrary.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateLowerOfOtherExe.cabal
+++ b/tests/goldenFiles/UpdateLowerOfOtherExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateLowerOfTest.cabal
+++ b/tests/goldenFiles/UpdateLowerOfTest.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateMajor1Lower.cabal
+++ b/tests/goldenFiles/UpdateMajor1Lower.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A <0.2,
@@ -23,8 +23,8 @@ library
         D -any
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A <0.2,

--- a/tests/goldenFiles/UpdateMajor1LowerAndUpper.cabal
+++ b/tests/goldenFiles/UpdateMajor1LowerAndUpper.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A ==0.*,
@@ -23,8 +23,8 @@ library
         D ==0.*
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D ==0.*
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.*,
@@ -59,8 +61,8 @@ executable other-exe
         D ==0.*
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.*,
@@ -77,8 +80,8 @@ test-suite some-test
         D ==0.*
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.*,

--- a/tests/goldenFiles/UpdateMajor1Upper.cabal
+++ b/tests/goldenFiles/UpdateMajor1Upper.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <1,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <1
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D ==0.*
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <1,
@@ -59,8 +61,8 @@ executable other-exe
         D ==0.*
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <1,
@@ -77,8 +80,8 @@ test-suite some-test
         D ==0.*
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <1,

--- a/tests/goldenFiles/UpdateMajor2Lower.cabal
+++ b/tests/goldenFiles/UpdateMajor2Lower.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D ==0.8.*
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,

--- a/tests/goldenFiles/UpdateMajor2Upper.cabal
+++ b/tests/goldenFiles/UpdateMajor2Upper.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -77,8 +80,8 @@ test-suite some-test
         D <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,

--- a/tests/goldenFiles/UpdateMinorLower.cabal
+++ b/tests/goldenFiles/UpdateMinorLower.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -59,8 +61,8 @@ executable other-exe
         D >=0.8.2
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,
@@ -77,8 +80,8 @@ test-suite some-test
         D >=0.8.2
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A ==0.1.*,

--- a/tests/goldenFiles/UpdateMinorLowerAndUpper.cabal
+++ b/tests/goldenFiles/UpdateMinorLowerAndUpper.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.8.3
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D >=0.8.2 && <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -59,8 +61,8 @@ executable other-exe
         D ==0.8.2.*
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -77,8 +80,8 @@ test-suite some-test
         D ==0.8.2.*
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,

--- a/tests/goldenFiles/UpdateMinorUpper.cabal
+++ b/tests/goldenFiles/UpdateMinorUpper.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.8.3
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -59,8 +61,8 @@ executable other-exe
         D <0.8.3
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,
@@ -77,8 +80,8 @@ test-suite some-test
         D <0.8.3
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.3.1,

--- a/tests/goldenFiles/UpdateOnlyMissing.cabal
+++ b/tests/goldenFiles/UpdateOnlyMissing.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -22,8 +22,8 @@ library
         C >=0.2.5 && <0.3
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -31,7 +31,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -39,8 +40,8 @@ executable cabal-bounds
         C >=0.1 && <0.4
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -48,7 +49,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -56,8 +58,8 @@ executable other-exe
         C >=0.1 && <0.4
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -65,7 +67,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -73,8 +76,8 @@ test-suite some-test
         C >=0.1 && <0.4
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -82,7 +85,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateUpperFromFile.cabal
+++ b/tests/goldenFiles/UpdateUpperFromFile.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <2.3,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <2.3,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <2.3,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <2.3,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <2.3,

--- a/tests/goldenFiles/UpdateUpperOfAll.cabal
+++ b/tests/goldenFiles/UpdateUpperOfAll.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -77,8 +80,8 @@ test-suite some-test
         D <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,

--- a/tests/goldenFiles/UpdateUpperOfAllExes.cabal
+++ b/tests/goldenFiles/UpdateUpperOfAllExes.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateUpperOfExe.cabal
+++ b/tests/goldenFiles/UpdateUpperOfExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateUpperOfLibrary.cabal
+++ b/tests/goldenFiles/UpdateUpperOfLibrary.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -23,8 +23,8 @@ library
         D >=0.7 && <0.9
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateUpperOfOtherExe.cabal
+++ b/tests/goldenFiles/UpdateUpperOfOtherExe.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -59,8 +61,8 @@ executable other-exe
         D <0.9
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -77,8 +80,8 @@ test-suite some-test
         D -any
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,

--- a/tests/goldenFiles/UpdateUpperOfTest.cabal
+++ b/tests/goldenFiles/UpdateUpperOfTest.cabal
@@ -1,10 +1,10 @@
 cabal-version: >=1.9.2
-name: setup-config
-version: 0.1
-license: UnspecifiedLicense
-maintainer: daniel.trstenjak@gmail.com
-author: Daniel Trstenjak
-build-type: Simple
+name:          setup-config
+version:       0.1
+license:       UnspecifiedLicense
+maintainer:    daniel.trstenjak@gmail.com
+author:        Daniel Trstenjak
+build-type:    Simple
 
 library
     exposed-modules:
@@ -12,9 +12,9 @@ library
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    hs-source-dirs: src
-    other-modules:
-        Paths_setup_config
+
+    hs-source-dirs:  src
+    other-modules:   Paths_setup_config
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -23,8 +23,8 @@ library
         D >=0.7
 
 executable cabal-bounds
-    main-is: ExeMain1.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain1.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -32,7 +32,8 @@ executable cabal-bounds
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -41,8 +42,8 @@ executable cabal-bounds
         D <0.9
 
 executable other-exe
-    main-is: ExeMain2.hs
-    cpp-options: -DCABAL
+    main-is:        ExeMain2.hs
+    cpp-options:    -DCABAL
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -50,7 +51,8 @@ executable other-exe
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,
@@ -59,8 +61,8 @@ executable other-exe
         D -any
 
 test-suite some-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain1.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain1.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -68,7 +70,8 @@ test-suite some-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.4,
@@ -77,8 +80,8 @@ test-suite some-test
         D <0.9
 
 test-suite other-test
-    type: exitcode-stdio-1.0
-    main-is: TestMain2.hs
+    type:           exitcode-stdio-1.0
+    main-is:        TestMain2.hs
     hs-source-dirs: src
     other-modules:
         Paths_setup_config
@@ -86,7 +89,8 @@ test-suite other-test
         CabalBounds.Command
         CabalBounds.Execute
         CabalBounds.Lenses
-    ghc-options: -W
+
+    ghc-options:    -W
     build-depends:
         base >=3,
         A >=0.1 && <0.2,


### PR DESCRIPTION
Update all golden tests as cabal now re-formats cabal files
even more.

Regarding re-formatting of cabal files we could possibly add support for updating in place via something like https://github.com/expipiplus1/update-nix-fetchgit/blob/master/src/Update/Span.hs if we can get position info from Cabal parser. It looks like there is `Distribution.Parsec.Position` but it only seems to be used by warnings and errors.

Needs https://github.com/dan-t/cabal-lenses/pull/9