### PR TITLE
Update for Cabal 3.14

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.6.0
+-----
+* Support Cabal 3.14
+
 2.5.0
 -----
 * Support ghc 9.8.2

--- a/cabal-bounds.cabal
+++ b/cabal-bounds.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10.0
 name:               cabal-bounds
-version:            2.5.0
+version:            2.6.0
 license:            BSD3
 license-file:       LICENSE
 maintainer:         daniel.trstenjak@gmail.com
@@ -98,7 +98,7 @@ library
         unordered-containers >=0.2.3.3 && <0.3,
         transformers >=0.3.0.0 && <0.7,
         cabal-lenses >=0.8.0 && <1.0,
-        Cabal >=3.12 && <4.0,
+        Cabal >=3.14 && <4.0,
         filepath >=1.3 && <1.6,
         directory >=1.2 && <1.4,
         aeson >=1.2.3.0 && <2.3,

--- a/lib/CabalBounds/Main.hs
+++ b/lib/CabalBounds/Main.hs
@@ -10,6 +10,7 @@ import Distribution.Parsec.Warning (PWarning)
 import qualified Distribution.PackageDescription.PrettyPrint as PP
 import Distribution.Simple.Configure (tryGetConfigStateFile)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
+import Distribution.Utils.Path (makeSymbolicPath)
 import qualified Distribution.Simple.LocalBuildInfo as BI
 import qualified Distribution.Package as P
 import qualified Distribution.Simple.PackageIndex as PX
@@ -210,7 +211,7 @@ haskellPlatformLibraries hpVersion =
 librariesFromSetupConfig :: SetupConfigFile -> ExceptT Error IO LibraryMap
 librariesFromSetupConfig ""       = return HM.empty
 librariesFromSetupConfig confFile = do
-   binfo <- liftIO $ tryGetConfigStateFile confFile
+   binfo <- liftIO $ tryGetConfigStateFile Nothing (makeSymbolicPath confFile)
    case binfo of
         Left e   -> throwE $ show e
         Right bi -> return $ buildInfoLibs bi


### PR DESCRIPTION
And finally this one, which follows on from https://github.com/dan-t/cabal-lenses/pull/10.

I don't think the line of code I changed is being tested, since the SetupConfig tests are not being run.

https://github.com/dan-t/cabal-bounds/blob/7bb32cb23bc715c9d405f947ed5704c86dbab768/tests/Main.hs#L63-L67

That said, the other tests pass and the executable builds, and I'm reasonably certain that the change I made preserves the behaviour (it interprets the config file relative to the working directory).